### PR TITLE
Changing coverage-root shortcut to r

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -4,7 +4,7 @@ const args = require('args')
 
 args
   .option(['j', 'coverage-json'], 'Relative path to istanbul coverage JSON', 'coverage/coverage-final.json')
-  .option(['h', 'coverage-html'], 'Relative path to coverage html root (for artifact links)', 'coverage/lcov-report')
+  .option(['r', 'coverage-root'], 'Relative path to coverage html root (for artifact links)', 'coverage/lcov-report')
   .option(['b', 'branch'], 'Base branch to use if not PR', 'master')
 
 const {


### PR DESCRIPTION
`h` can not be used as a shortcut since that is already the shortcut for help. Also, the documentation is not currently matching with the options in code.